### PR TITLE
fix p-line in examples in format.html

### DIFF
--- a/2020/format.html
+++ b/2020/format.html
@@ -52,7 +52,7 @@ The changes will be as follows:
 Instance in the current format:
 <code>c This is a comment
 c Example 1...another comment
-p 7 4 12 
+p wcnf 7 4 12 
 12 1 2 3 4 0
 1 -3 -5 6 7 0
 6 -1 -2 0

--- a/2021/format.html
+++ b/2021/format.html
@@ -52,7 +52,7 @@ The changes will be as follows:
 Instance in the current format:
 <code>c This is a comment
 c Example 1...another comment
-p 7 4 12 
+p wcnf 7 4 12 
 12 1 2 3 4 0
 1 -3 -5 6 7 0
 6 -1 -2 0


### PR DESCRIPTION
I guess that the `wcnf` keyword is missing in the old WCNF file example in the `format.html` file.