### PR TITLE
Fix solver link to UWrMaxSat-SCIP in participating solvers page of MSE2024 

### DIFF
--- a/2024/contents/contents_descriptions.html
+++ b/2024/contents/contents_descriptions.html
@@ -38,7 +38,7 @@
       <li><a href="mse24-solver-src/exact/weighted/EvalMaxSAT_2024.zip">EvalMaxSAT_2024</a></li>
       <li><a href="mse24-solver-src/exact/weighted/Exact.zip">Exact</a></li>
       <li><a href="mse24-solver-src/exact/weighted/Pacose24.zip">Pacose24</a></li>
-      <li><a href="mse24-solver-src/exact/weighted/UWrMaxSat-SCIP-MaxPre.zip">UWrMaxSat-SCIP-MaxPre</a></li>
+      <li><a href="mse24-solver-src/exact/weighted/UWrMaxSat-SCIP.zip">UWrMaxSat-SCIP</a></li>
       <li><a href="mse24-solver-src/exact/weighted/WMaxCDCL2024.zip">WMaxCDCL2024</a></li>
     </ul></li>
 


### PR DESCRIPTION
On the ["Participating Solvers"  page of MaxSAT Evaluation 2024](https://maxsat-evaluations.github.io/2024/descriptions.html), the link to `UWrMaxSat-SCIP-MaxPre` under the weighted section is broken. It points to <https://maxsat-evaluations.github.io/2024/mse24-solver-src/exact/weighted/UWrMaxSat-SCIP-MaxPre.zip> but the file is missing.

![image](https://github.com/user-attachments/assets/abf3ef23-1c2b-4017-8510-11d9e10f1dc7)

I guess it would be correct to link to the `UWrMaxSat-SCIP.zip` file in the same directory.
